### PR TITLE
Add DevContainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+# [Choice] Ruby version: 2, 2.7, 2.6, 2.5
+ARG VARIANT=2
+FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+RUN gem install bundler -v "2.1.4"
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+    "name": "Ruby",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            "VARIANT": "2.6",
+            "INSTALL_NODE": "true",
+            "NODE_VERSION": "lts/*"
+        }
+    },
+
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash",
+    },
+
+    "extensions": [
+        "rebornix.Ruby"
+    ],
+
+    "remoteUser": "vscode",
+
+    "postAttachCommand": "bundle install"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,5 +19,9 @@
 
     "remoteUser": "vscode",
 
-    "postAttachCommand": "bundle install"
+    "postAttachCommand": "bundle install",
+
+    "mounts": [
+        "source=${localWorkspaceFolder}/../unpoly,target=/workspaces/unpoly,type=bind,consistency=cached"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ add a `RewriteRule` to `source/.htaccess` to existing links will keep working.
 - Start a development server with `bundle exec middleman server`
 - Test your changes on `http://localhost:4567`
 
+## Local development using a DevContainer
+
+If you're using an editor such as VSCode and have Docker available, you can use
+the DevContainer configuration provided without requiring any dependencies.
+
+1. Checkout `unpoly-site` alongside `unpoly` in the same parent folder (as above).
+2. Open project in VSCode.
+3. When prompted, choose to Reopen in Devcontainer.
+
+Once inside the DevContainer, use `bundle exec middleman server` and `bundle exec rspec`
+as you normally would.
 
 ## Tests
 


### PR DESCRIPTION
For editors that support it (ie. VSCode), introduce a DevContainer configuration which streamlines project setup for contributing.