### PR TITLE
Mention unsupported attrs on `<script>` tag

### DIFF
--- a/source/install/index.html.erb
+++ b/source/install/index.html.erb
@@ -82,6 +82,8 @@
   <p>
     Unpoly automatically initializes on the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event"><code>DOMContentLoaded</code></a>
     event and runs your <a href="http://localhost:4567/up.compiler">compilers</a> on the initial page.
+
+    Using <code>[async]</code>, <code>[defer]</code>, or <code>[type=module]</code> on the <code>&lt;script&gt;</code> tag that loads Unpoly is currently unsupported.
   </p>
 
   <p>


### PR DESCRIPTION
The `async`, `defer`, and `type=module` attributes are currently
not supported on the `<script>` tag that loads Unpoly.

This has come up frequently enough that we should mention it.

![image](https://user-images.githubusercontent.com/17083/129186840-90234ce4-ad7c-460b-9734-72d50dd24031.png)
