### PR TITLE
Fix DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,16 @@
 # [Choice] Ruby version: 2, 2.7, 2.6, 2.5
 ARG VARIANT=2
-FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
+FROM ruby:${VARIANT}
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends sudo nodejs
+
+RUN echo 'vscode ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/vscode && \
+  chmod 440 /etc/sudoers.d/vscode
+
+RUN useradd -ms /bin/bash vscode
+
+USER vscode
 
 RUN gem install bundler -v "2.1.4"
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,6 @@
         "dockerfile": "Dockerfile",
         "args": {
             "VARIANT": "2.6",
-            "INSTALL_NODE": "true",
-            "NODE_VERSION": "lts/*"
         }
     },
 
@@ -22,6 +20,7 @@
     "postAttachCommand": "bundle install",
 
     "mounts": [
-        "source=${localWorkspaceFolder}/../unpoly,target=/workspaces/unpoly,type=bind,consistency=cached"
+        "source=${localWorkspaceFolder}/../unpoly,target=/workspaces/unpoly,type=bind,consistency=cached",
+        "source=${localWorkspaceFolder}/../unpoly-rails,target=/workspaces/unpoly-rails,type=bind,consistency=cached"
     ]
 }


### PR DESCRIPTION
Replace vscode Docker image with official Ruby image, so it works multi-platform (Apple M1 without qemu).

Update Dockerfile to install dependencies expected for DevContainer functionality.

Update mounts to add `unpoly-rails` to workspace.