### PR TITLE
Replace unpkg.com with jsdelivr.net

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -273,11 +273,11 @@ helpers do
   end
 
   def cdn_url(file)
-    "https://unpkg.com/unpoly@#{guide.version}/#{file}"
+    "https://cdn.jsdelivr.net/npm/unpoly@#{guide.version}/#{file}"
   end
 
   def cdn_browse_url(filename = nil)
-    "https://unpkg.com/unpoly@#{guide.version}/#{filename}"
+    "https://cdn.jsdelivr.net/npm/unpoly@#{guide.version}/#{filename}"
   end
 
   def link_to_cdn_file(filename, link_options = {})


### PR DESCRIPTION
The unpkg.com CDN has had a number of issues the last few months, much more than the jsdelivr.net CDN (which is 0 AFAIK).

Furthermore, the jsdelivr.net CDN seems to be architected somewhat more resilient to failure, utilizing multiple CDN and DNS services.