### PR TITLE
Docker compose development instructions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,4 +13,4 @@ RUN useradd -ms /bin/bash vscode
 
 USER vscode
 
-RUN gem install bundler -v "2.1.4"
+RUN gem install bundler -v "1.17.3"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,20 @@
+---
+version: "3.7"
+services: 
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VARIANT: "2.6"
+    command: "/bin/bash -c '(bundle check || bundle install) && bundle exec middleman serve'"
+    volumes:
+      - "../../unpoly:/workspaces/unpoly"
+      - "../../unpoly-rails:/workspaces/unpoly-rails"
+      - "..:/workspaces/unpoly-site"
+      - "bundle:/usr/local/bundle"
+    ports:
+      - 4567:4567
+    working_dir: /workspaces/unpoly-site
+volumes:
+  bundle:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ If you're using an editor such as VSCode and have Docker available, you can use 
 
 Once inside the DevContainer, use `bundle exec middleman server` and `bundle exec rspec` as you normally would.
 
+
+## Local development using Docker Compose
+
+You can use Docker to run the development dependencies and middleman sever.
+
+1. Checkout `unpoly-site` alongside `unpoly` in the same parent folder (as above).
+2. From inside the `unpoly-site` folder, run the command below.
+
+        docker compose -p unpoly-site -f .devcontainer/docker-compose.yml run --service-ports app
+
+Once the container is running, you can browse documentation from the outside at https://localhost:4567
+
 ## Tests
 
 This repo should have a lot more tests.


### PR DESCRIPTION
Similar to the DevContainer set up, provide instructions on how to run the development server with `docker compose`.