### PR TITLE
Run the test suite on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,65 @@
+---
+name: Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    name: RSpec
+    env:
+      # The deploy group is only needed for `cap deploy` and pulls a gem from git.
+      BUNDLE_WITHOUT: deploy
+    defaults:
+      run:
+        working-directory: unpoly-site
+    steps:
+      # The committed symlink `vendor/unpoly-local` points at `../unpoly`, so both
+      # repositories must be checked out next to each other. The site is unusable
+      # without it: the specs parse their documentation from that checkout, and the
+      # site's own frontend is served from its build in `unpoly/dist`.
+      - name: Check out unpoly-site
+        uses: actions/checkout@v4
+        with:
+          path: unpoly-site
+
+      - name: Check out unpoly
+        uses: actions/checkout@v4
+        with:
+          repository: unpoly/unpoly
+          path: unpoly
+
+      - name: Install Ruby from .ruby-version
+        uses: ruby/setup-ruby@v1
+        with:
+          working-directory: unpoly-site
+          ruby-version: ".ruby-version"
+          bundler-cache: true
+
+      - name: Install Node.js from unpoly's .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: unpoly/.nvmrc
+          cache: npm
+          cache-dependency-path: unpoly/package-lock.json
+
+      - name: Install npm dependencies of unpoly
+        run: npm ci
+        working-directory: unpoly
+
+      # `unpoly/dist` is not committed, but the asset pipeline requires `unpoly.js`
+      # from it when a feature spec renders a page with JavaScript.
+      - name: Build unpoly
+        run: npm run build
+        working-directory: unpoly
+
+      # Chrome and chromedriver for the `js: true` feature specs are preinstalled
+      # on the runner image.
+      - name: Run tests
+        run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ end
 group :test do
   gem 'rspec'
   gem 'capybara'
-  gem 'selenium-webdriver', '>=3'
+  gem 'selenium-webdriver', '>= 4'
   gem 'puma'
   # gem 'webrick'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/makandra/capistrano-middleman.git
-  revision: 26cb59981e0ae2f300625b39c9e78732ced5d38c
+  revision: 8c4a8630a8570d5a655d46d12804cfe289ecf62e
   specs:
     capistrano-middleman (0.2.0)
       capistrano (~> 3)
       middleman (~> 4.0)
-      rubyzip (~> 1.1.7)
+      rubyzip (>= 1.1.7, < 3)
 
 GEM
   remote: https://rubygems.org/
@@ -50,8 +50,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -198,7 +196,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.4)
-    rubyzip (1.1.7)
+    rubyzip (2.4.1)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -207,9 +205,12 @@ GEM
     sassc (2.4.0)
       ffi (~> 1.9)
     securerandom (0.4.1)
-    selenium-webdriver (3.8.0)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.0)
+    selenium-webdriver (4.48.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 4.0)
+      websocket (~> 1.0)
     servolux (0.13.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
@@ -237,6 +238,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     uri (1.0.3)
     webrick (1.9.1)
+    websocket (1.2.11)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yell (2.2.2)
@@ -264,7 +266,7 @@ DEPENDENCIES
   rack
   rspec
   sass
-  selenium-webdriver (>= 3)
+  selenium-webdriver (>= 4)
   terser
   webrick
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,23 +1,27 @@
+# Must be loaded before the first example, so that Capybara's own `before` hook
+# is registered in time to switch the driver for examples tagged `js: true`.
+require 'capybara/rspec'
+
+Capybara.register_driver :selenium do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless=new') unless ENV.key?('NO_HEADLESS')
+  options.add_argument('--disable-infobars')
+  options.add_emulation(device_metrics: { width: 1280, height: 960, touch: false })
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Selenium::WebDriver.logger.level = :error
+
+Capybara.javascript_driver = :selenium
+# Capybara.server = :webrick
+
+# Booting Middleman takes a moment, so we only do it once, and only when a feature
+# spec actually runs.
 def configure_capybara_once
   return if Capybara.app
 
-  require 'capybara/rspec'
   require 'middleman-core'
   require 'middleman-core/rack'
-
-  Capybara.register_driver :selenium do |app|
-    options = Selenium::WebDriver::Chrome::Options.new
-    options.add_argument('--headless') unless ENV.key?('NO_HEADLESS')
-    options.add_argument('--disable-infobars')
-    options.add_option('w3c', false)
-    options.add_emulation(device_metrics: { width: 1280, height: 960, touch: false })
-    Capybara::Selenium::Driver.new(app, browser: :chrome , options: options)
-  end
-
-  Selenium::WebDriver.logger.level = :error
-
-  Capybara.javascript_driver = :selenium
-  # Capybara.server = :webrick
 
   middleman_app = ::Middleman::Application.new do
     set :root, File.expand_path(File.join(File.dirname(__FILE__), '..'))


### PR DESCRIPTION
Runs `bundle exec rspec` on pushes to master and on PRs against master.

Because the specs read their content through the `vendor/unpoly-local` symlink, the workflow checks out `unpoly/unpoly` next to this repo and builds it (`dist/` is not committed, but Sprockets needs `unpoly.js` from it when a feature spec renders a page).

The suite could not pass before:

- `spec/support/capybara.rb` required `capybara/rspec` inside a `before(:each)` hook, so Capybara's driver-switching hook was registered too late and `js: true` examples silently ran under RackTest. The require and the driver registration now happen at load time; booting Middleman stays lazy.
- `selenium-webdriver` was locked at 3.8.0 (2017), which cannot drive current Chrome. It is now 4.x, which also made `options.add_option('w3c', false)` obsolete.

The Selenium 4 upgrade needed `rubyzip >= 1.2.2`, which `capistrano-middleman` prevented by pinning `rubyzip ~> 1.1.7`. That pin is loosened to `>= 1.1.7, < 3` in makandra/capistrano-middleman@8c4a863; the `< 3` cap keeps `Zip::File::CREATE` available, which the gem uses. Middleman stays at 4.6.1.